### PR TITLE
allow to manually define the auth token for client and settings

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,7 @@ namespace Pb;
 class Client
 {
     private string $url;
+    private string $token = '';
 
     public function __construct(string $url)
     {
@@ -13,11 +14,16 @@ class Client
 
     public function collection(string $collection): Collection
     {
-        return new Collection($this->url ,$collection);
+        return new Collection($this->url ,$collection, $this->token);
     }
 
     public function settings(): Settings
     {
-        return new Settings($this->url);
+        return new Settings($this->url, $this->token);
+    }
+
+    public function setAuthToken(string $token): void
+    {
+        $this->token = $token;
     }
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -25,11 +25,13 @@ class Collection
     /**
      * @param string $url
      * @param string $collection
+     * @param string $token
      */
-    public function __construct(string $url, string $collection)
+    public function __construct(string $url, string $collection, string $token)
     {
         $this->url = $url;
         $this->collection = $collection;
+        self::$token = $token;
     }
 
     /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -19,11 +19,12 @@ class Settings
 
     /**
      * @param string $url
-     * @param string $collection
+     * @param string $token
      */
-    public function __construct(string $url)
+    public function __construct(string $url, string $token)
     {
         $this->url = $url;
+        self::$token = $token;
     }
 
     public function authAsAdmin(string $email, string $password): void


### PR DESCRIPTION
I added the ability to manually set the AuthToken in Pocketbase, which will simply replace the value in Settings and Client from the moment it is defined.

Example of usage:
```php
use \Pb\Client as pb;
$pb = new pb('https://admin.pocketbase.dev');
$pb->setAuthToken($myToken);
var_dump($pb->collection('users')->getList());
```

This is useful when you don't use the classic auth method (email, password) of Pocketbase, but your users need to be logged in. For example, if you use an external SSO and only have a token for logging in.

I hope this can help some people.